### PR TITLE
Add return_pages parameter to pdf_to_text

### DIFF
--- a/src/kern/pdf/lib.py
+++ b/src/kern/pdf/lib.py
@@ -2,11 +2,11 @@ __all__ = [
     'pdf_to_text',
 ]
 
-def pdf_to_text(file):
+def pdf_to_text(file, return_pages=False) -> str | list[str]:
     import pypdf
     import assure
     # assure file is seekable to support stdin.
     file = assure.seekable(file)
     reader = pypdf.PdfReader(file)
     pages = [page.extract_text() for page in reader.pages]
-    return '\n\n'.join(pages)
+    return pages if return_pages else '\n\n'.join(pages)

--- a/src/kern/pdf/lib.py
+++ b/src/kern/pdf/lib.py
@@ -1,12 +1,17 @@
 __all__ = [
+    'pdf_to_pages',
     'pdf_to_text',
 ]
 
-def pdf_to_text(file, return_pages=False) -> str | list[str]:
+def pdf_to_pages(file):
     import pypdf
     import assure
     # assure file is seekable to support stdin.
     file = assure.seekable(file)
     reader = pypdf.PdfReader(file)
     pages = [page.extract_text() for page in reader.pages]
-    return pages if return_pages else '\n\n'.join(pages)
+    return pages
+
+def pdf_to_text(file):
+    pages = pdf_to_pages(file)
+    return '\n\n'.join(pages)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -10,6 +10,29 @@ def test_pdf_lib():
     text = pdf.pdf_to_text(file)
     assert 'chicken' in text
 
+def test_pdf_lib_return_pages():
+    file = "files/chicken.pdf"
+    text = pdf.to_text(file, return_pages=True)
+    assert not isinstance(text, str)
+    assert all(isinstance(page, str) for page in text)
+    assert 'chicken' in '\n\n'.join(text)
+
+    file = "files/chicken.pdf"
+    text = pdf.to_text(file, return_pages=False)
+    assert isinstance(text, str)
+    assert 'chicken' in text
+
+    file = "files/chicken.pdf"
+    text = pdf.pdf_to_text(file, return_pages=True)
+    assert not isinstance(text, str)
+    assert all(isinstance(page, str) for page in text)
+    assert 'chicken' in '\n\n'.join(text)
+
+    file = "files/chicken.pdf"
+    text = pdf.pdf_to_text(file, return_pages=False)
+    assert isinstance(text, str)
+    assert 'chicken' in text
+
 def test_pdf_bin():
     pipe = os.popen("cat files/chicken.pdf | pdf")
     assert 'chicken' in pipe.read()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,37 +1,15 @@
 import os
-from kern import pdf
+from kern.pdf import pdf_to_text, pdf_to_pages
 
 def test_pdf_lib():
     file = "files/chicken.pdf"
-    text = pdf.to_text(file)
+
+    text = pdf_to_text(file)
     assert 'chicken' in text
 
-    file = "files/chicken.pdf"
-    text = pdf.pdf_to_text(file)
-    assert 'chicken' in text
-
-def test_pdf_lib_return_pages():
-    file = "files/chicken.pdf"
-    text = pdf.to_text(file, return_pages=True)
-    assert not isinstance(text, str)
-    assert all(isinstance(page, str) for page in text)
-    assert 'chicken' in '\n\n'.join(text)
-
-    file = "files/chicken.pdf"
-    text = pdf.to_text(file, return_pages=False)
-    assert isinstance(text, str)
-    assert 'chicken' in text
-
-    file = "files/chicken.pdf"
-    text = pdf.pdf_to_text(file, return_pages=True)
-    assert not isinstance(text, str)
-    assert all(isinstance(page, str) for page in text)
-    assert 'chicken' in '\n\n'.join(text)
-
-    file = "files/chicken.pdf"
-    text = pdf.pdf_to_text(file, return_pages=False)
-    assert isinstance(text, str)
-    assert 'chicken' in text
+    pages = pdf_to_pages(file)
+    assert isinstance(pages, list)
+    assert all('chicken' in page for page in pages)
 
 def test_pdf_bin():
     pipe = os.popen("cat files/chicken.pdf | pdf")


### PR DESCRIPTION
I have a pre-processing (pre-embed) step that relies on the position of text relative to page breaks. This PR adds a parameter to optionally return the pages instead of the joined text.